### PR TITLE
Feature/mi 19 bigcommerce token and customer services

### DIFF
--- a/packages/modules/bigcommerce/src/apis/rest/customer-impersonation-token.ts
+++ b/packages/modules/bigcommerce/src/apis/rest/customer-impersonation-token.ts
@@ -9,6 +9,11 @@ const QUERY_DEFAULT_TTL = CACHE_ITEMS_TTL?.[CACHE_KEY__CUSTOMER_IMPERSONATION_TO
 // We time we extend the tokens' Time To Live (TTL) beyond the duration it's stored in the cache
 const QUERY_TTL_BUFFER_IN_MILLISECONDS = 600000; // 10 minutes
 
+/**
+ * @deprecated since version 1.1.0, will be removed in version 2.0.0
+ *
+ * Use {@link BigCommerceTokenService} via dependency injection instead
+ */
 export const getCustomerImpersonationToken = async (context: GraphQLModules.ModuleContext) => {
     /* Gets the ttl from client specific projects context otherwise fallback to the default TLL */
     const tokenTtlInMilliseconds =
@@ -30,6 +35,11 @@ export const getCustomerImpersonationToken = async (context: GraphQLModules.Modu
     return createCustomerImpersonationToken(expiresAt);
 };
 
+/**
+ * @deprecated since version 1.1.0, will be removed in version 2.0.0
+ *
+ * Use {@link BigCommerceTokenService} via dependency injection instead
+ */
 export const retrieveCustomerImpersonationTokenFromCache = async (
     context: GraphQLModules.ModuleContext
 ): Promise<string> => {

--- a/packages/modules/bigcommerce/src/clients/big-commerce-graphql-client.ts
+++ b/packages/modules/bigcommerce/src/clients/big-commerce-graphql-client.ts
@@ -49,7 +49,7 @@ export class BigCommerceGraphQlClient {
         @Inject(forwardRef(() => ModuleConfig)) private config: BigCommerceModuleConfig,
         private tokenService: BigCommerceTokenService
     ) {
-        const sdk = buildBigCommerceAxiosSdk(config, this.tokenService);
+        const sdk = buildBigCommerceAxiosSdk(config, tokenService);
         Object.assign(this, sdk);
     }
 }

--- a/packages/modules/bigcommerce/src/providers/index.ts
+++ b/packages/modules/bigcommerce/src/providers/index.ts
@@ -2,6 +2,7 @@ import { InjectionToken, Provider, Scope } from 'graphql-modules';
 import { BigCommerceModuleConfig } from '../index';
 import { Get, Paths } from 'type-fest';
 import { BigCommerceGraphQlClient } from '../clients';
+import { BigCommerceTokenService, BigCommerceCustomerService } from '../services';
 
 export const ModuleConfig = new InjectionToken<BigCommerceModuleConfig>(
     'Configuration for the BigCommerce GraphQL Module'
@@ -38,5 +39,7 @@ export const getProviders = (config: BigCommerceModuleConfig): Array<Provider> =
             global: true,
         },
         BigCommerceGraphQlClient,
+        BigCommerceTokenService,
+        BigCommerceCustomerService,
     ];
 };

--- a/packages/modules/bigcommerce/src/resolvers/mutations/clear-customer-cart.ts
+++ b/packages/modules/bigcommerce/src/resolvers/mutations/clear-customer-cart.ts
@@ -1,8 +1,7 @@
 import { MutationResolvers } from '@aligent/bigcommerce-resolvers';
 import { logAndThrowError } from '@aligent/utils';
-import { getBcCustomerId } from '../../utils';
-import { deleteCart } from '../../apis/graphql/delete-cart';
-import { retrieveCustomerImpersonationTokenFromCache } from '../../apis/rest';
+import { BigCommerceCustomerService } from '../../services';
+import { BigCommerceGraphQlClient } from '../../clients';
 
 export const UNDEFINED_CART = {
     id: '',
@@ -20,16 +19,23 @@ export const clearCustomerCartResolver = {
         if (!args.cartUid) {
             return logAndThrowError('Missing cart uid');
         }
-        const customerImpersonationToken =
-            await retrieveCustomerImpersonationTokenFromCache(context);
 
-        const bcCustomerId = getBcCustomerId(context);
+        const customerService = context.injector.get(BigCommerceCustomerService);
+        const headers = customerService.customerHeaders;
 
-        const response = await deleteCart(args.cartUid, customerImpersonationToken, bcCustomerId);
+        const graphQlClient = context.injector.get(BigCommerceGraphQlClient);
+        const status = await graphQlClient
+            .deleteCart({ cartEntityId: args.cartUid }, { headers })
+            .then((response) => {
+                if (response.errors) {
+                    logAndThrowError(response.errors);
+                }
+                return response.data?.cart.deleteCart;
+            });
 
         return {
             cart: UNDEFINED_CART,
-            status: !!response,
+            status: !!status,
         };
     },
 } satisfies MutationResolvers['clearCustomerCart'];

--- a/packages/modules/bigcommerce/src/resolvers/mutations/generate-customer-token.ts
+++ b/packages/modules/bigcommerce/src/resolvers/mutations/generate-customer-token.ts
@@ -1,17 +1,17 @@
 import { MutationResolvers } from '@aligent/bigcommerce-resolvers';
 import { bcLogin } from '../../apis/graphql/login';
-import { generateMeshToken } from '../../utils';
-import { retrieveCustomerImpersonationTokenFromCache } from '../../apis/rest';
+import { BigCommerceTokenService } from '../../services/bigcommerce-token-service';
 
 export const generateCustomerTokenResolver: MutationResolvers['generateCustomerToken'] = {
     resolve: async (_root, args, context, _info) => {
-        const customerImpersonationToken =
-            await retrieveCustomerImpersonationTokenFromCache(context);
+        const tokenService = context.injector.get(BigCommerceTokenService);
 
+        const customerImpersonationToken = await tokenService.customerImpersonationToken;
         const entityId = await bcLogin(args.email, args.password, customerImpersonationToken);
+        const token = tokenService.generateMeshToken(entityId);
 
         return {
-            token: generateMeshToken(entityId),
+            token,
         };
     },
 };

--- a/packages/modules/bigcommerce/src/services/bigcommerce-customer-service.ts
+++ b/packages/modules/bigcommerce/src/services/bigcommerce-customer-service.ts
@@ -81,8 +81,10 @@ export class BigCommerceCustomerService {
      */
     get customerHeaders() {
         const id = this.customerId.valueOrUndefined;
-        return {
-            ...(id && { 'x-bc-customer-id': id }),
-        };
+        if (id === undefined) {
+            return {};
+        }
+
+        return { 'x-bc-customer-id': id };
     }
 }

--- a/packages/modules/bigcommerce/src/services/bigcommerce-customer-service.ts
+++ b/packages/modules/bigcommerce/src/services/bigcommerce-customer-service.ts
@@ -1,0 +1,88 @@
+import { Injectable, ExecutionContext, Inject, forwardRef } from 'graphql-modules';
+import { BigCommerceModuleConfig } from '..';
+import { ModuleConfig } from '../providers';
+import { verify } from 'jsonwebtoken';
+import { MeshToken } from '../types';
+import { GraphqlError } from '@aligent/utils';
+
+// Private key used to sign Mesh tokens
+const JWT_PRIVATE_KEY = process.env.JWT_PRIVATE_KEY as string;
+
+@Injectable({ global: true })
+export class BigCommerceCustomerService {
+    @ExecutionContext() private context: ExecutionContext;
+
+    constructor(@Inject(forwardRef(() => ModuleConfig)) private config: BigCommerceModuleConfig) {}
+
+    private constructCustomerIdResponse(
+        data: { value: number } | { value: undefined; message: string }
+    ) {
+        const { value } = data;
+        return {
+            get valueOrUndefined() {
+                return value;
+            },
+            get valueOrError() {
+                if (value === undefined) {
+                    throw new GraphqlError(data.message, 'authentication');
+                }
+
+                return value;
+            },
+        };
+    }
+
+    /**
+     * Extracts the customer id for the current request. It returns an object
+     * presenting two ways to get the value of the id. Each will return the
+     * customer id if successfully extracted, but behave differently extraction
+     * failed:
+     *
+     * * valueOrUndefined - Returns undefined. Use when a customer id is not strictly required.
+     * * valueOrError - Throws an error.
+     * @returns {Object}
+     */
+    get customerId(): ReturnType<typeof this.constructCustomerIdResponse> {
+        try {
+            const token = this.context.headers.authorization;
+
+            if (!token || !token.toLowerCase().startsWith('bearer ')) {
+                return this.constructCustomerIdResponse({
+                    value: undefined,
+                    message: 'Need to send Bearer token',
+                });
+            }
+
+            const splitMeshToken = token.split(' ')[1];
+
+            const decodedMeshToken = verify(splitMeshToken, JWT_PRIVATE_KEY) as MeshToken;
+            return this.constructCustomerIdResponse({
+                value: decodedMeshToken.bc_customer_id,
+            });
+        } catch (error) {
+            /* For whatever reason decrypting the meshToken fails, send an error which
+             * will trigger the PWA to end the browsers user session
+             *
+             * possible error.messages 'jwt expired', 'jwt malformed', 'invalid signature'
+             *
+             * @external https://www.npmjs.com/package/jsonwebtoken#errors--codes
+             * */
+
+            return this.constructCustomerIdResponse({
+                value: undefined,
+                message: 'User session has expired',
+            });
+        }
+    }
+
+    /**
+     * Returns preformatted x-bc-customer-id headers for GraphQL requests
+     * If no customer id is available, returns an empty object
+     */
+    get customerHeaders() {
+        const id = this.customerId.valueOrUndefined;
+        return {
+            ...(id && { 'x-bc-customer-id': id }),
+        };
+    }
+}

--- a/packages/modules/bigcommerce/src/services/bigcommerce-token-service.ts
+++ b/packages/modules/bigcommerce/src/services/bigcommerce-token-service.ts
@@ -1,0 +1,95 @@
+import { ExecutionContext, forwardRef, Inject, Injectable } from 'graphql-modules';
+
+import { CACHE_ITEMS_TTL, CACHE_KEY__CUSTOMER_IMPERSONATION_TOKEN } from '../constants';
+import { ModuleConfig } from '../providers';
+import {
+    BigCommerceModuleConfig,
+    createCustomerImpersonationToken,
+    getDataFromMeshCache,
+} from '..';
+import { getUnixTimeStampInSecondsForMidnightTonight } from '@aligent/utils';
+import { sign } from 'jsonwebtoken';
+
+// The default "customer_impersonation_token" query TTL should one not be stored in "CACHE_ITEMS_TTL"
+const QUERY_DEFAULT_TTL = CACHE_ITEMS_TTL?.[CACHE_KEY__CUSTOMER_IMPERSONATION_TOKEN] || 86400000;
+
+// We time we extend the tokens' Time To Live (TTL) beyond the duration it's stored in the cache
+const QUERY_TTL_BUFFER_IN_MILLISECONDS = 10 * 60 * 1000; // minutes x seconds/min x ms/second
+
+// Private key used to sign Mesh tokens
+const JWT_PRIVATE_KEY = process.env.JWT_PRIVATE_KEY as string;
+
+@Injectable({ global: true })
+export class BigCommerceTokenService {
+    @ExecutionContext() private context: ExecutionContext;
+
+    private tokenTtlInMilliseconds: number;
+
+    constructor(@Inject(forwardRef(() => ModuleConfig)) private config: BigCommerceModuleConfig) {
+        /* Gets the ttl from client specific projects context otherwise fallback to the default TLL */
+        const cacheTtlInMilliseconds =
+            config.cacheItemsTtl?.[CACHE_KEY__CUSTOMER_IMPERSONATION_TOKEN] || QUERY_DEFAULT_TTL;
+
+        /* Not to be confused with the "customer_impersonation_token" cache TTL.
+         * This TTL ensures the token itself lasts longer than the time we store it in the cache.
+         * We do this to prevent getting caught with an expired "customer_impersonation_token"
+         * mid-way through resolver requests. An example is the cart resolver is called and makes the first
+         * request then the "customer_impersonation_token" expires making the second request fail. */
+        this.tokenTtlInMilliseconds = cacheTtlInMilliseconds + QUERY_TTL_BUFFER_IN_MILLISECONDS;
+    }
+
+    private requestNewCustomerImpersonationToken = () => {
+        const currentTime = new Date().getTime();
+        const currentDatePlusTokenTtl = new Date(
+            currentTime + this.tokenTtlInMilliseconds
+        ).getTime();
+        const expiresAt = Number((currentDatePlusTokenTtl / 1000).toFixed(0));
+        return createCustomerImpersonationToken(expiresAt);
+    };
+
+    /**
+     * A BigCommerce token allowing server-to-server requests as any customer
+     *
+     * - anonymous customer if used by itself
+     * - a specific customer account if paired with the `x-bc-customer-id` header
+     *
+     *
+     * The value will be retrieved from the cache if possible, otherwise a new
+     * token will be generated and cached
+     *
+     * @example
+     * ```
+     * const customerImpersonationToken =
+            await context.injector.get(BigCommerceTokenService).customerImpersonationToken;
+            const cartHeader = {
+            Authorization: `Bearer ${customerImpersonationToken}`,
+            ...(bcCustomerId && { 'x-bc-customer-id': bcCustomerId }),
+        };
+        const response = await bcGraphQlRequest(createCartQuery, cartHeader);
+        ```
+     *
+     * @external https://developer.bigcommerce.com/docs/start/authentication/graphql-storefront#customer-impersonation-tokens
+     */
+    get customerImpersonationToken() {
+        return getDataFromMeshCache(
+            this.context,
+            CACHE_KEY__CUSTOMER_IMPERSONATION_TOKEN,
+            this.requestNewCustomerImpersonationToken
+        );
+    }
+
+    /**
+     * Creates a signed JWT containing a customer's bc_customer_id in the payload
+     * which can then be provided to the mesh to allow requests as that user
+     *
+     * @param {number} customerId - Bc User Id returned from logging in
+     */
+    generateMeshToken(customerId: number) {
+        const payload = {
+            bc_customer_id: customerId,
+            exp: getUnixTimeStampInSecondsForMidnightTonight(),
+        };
+
+        return sign(payload, JWT_PRIVATE_KEY);
+    }
+}

--- a/packages/modules/bigcommerce/src/services/index.ts
+++ b/packages/modules/bigcommerce/src/services/index.ts
@@ -1,0 +1,2 @@
+export * from './bigcommerce-token-service';
+export * from './bigcommerce-customer-service';

--- a/packages/modules/bigcommerce/src/utils/mesh-cache.ts
+++ b/packages/modules/bigcommerce/src/utils/mesh-cache.ts
@@ -22,11 +22,11 @@ const ENABLE_CACHE_LOGGING = !!Number(process.env.DEBUG);
  * const dataFromCache = await getDataFromMeshCache(context, "store-config", uninvokedQuery);
  *
  */
-export const getDataFromMeshCache = async (
+export const getDataFromMeshCache = async <T>(
     context: GraphQLModules.ModuleContext,
     cacheKey: string,
-    query: () => Promise<unknown>
-): Promise<AxiosResponse['data']> => {
+    query: () => Promise<T>
+): Promise<AxiosResponse<T>['data']> => {
     const ns = xray.getNamespace();
 
     // The getSegment function does not know if it's a segment or a subsegment

--- a/packages/modules/bigcommerce/src/utils/tokens.ts
+++ b/packages/modules/bigcommerce/src/utils/tokens.ts
@@ -13,6 +13,9 @@ const BC_CLIENT_SECRET = process.env.BC_CLIENT_SECRET as string;
 const STORE_HASH = process.env.STORE_HASH as string;
 
 /* istanbul ignore file */
+/**
+ * @deprecated since version 1.1.0, will be removed in version 2.0.0
+ */
 export const getDecodedCustomerImpersonationToken = (
     customerImpersonationToken: string
 ): DecodedCustomerImpersonationToken => {
@@ -24,6 +27,10 @@ export const getDecodedCustomerImpersonationToken = (
 };
 
 /**
+ * @deprecated since version 1.1.0, will be removed in version 2.0.0
+ *
+ * Use {@link BigCommerceTokenService} via dependency injection instead
+ *
  * Attempts to extract "bc_customer_id" for the mesh token or throws an error
  * @param meshToken
  */
@@ -48,6 +55,11 @@ export const getBcCustomerIdFromMeshToken = (meshToken: string): number => {
 };
 
 /**
+ * @deprecated since version 1.1.0, will be removed in version 2.0.0
+ *
+ * Use {@link BigCommerceTokenService} via dependency injection instead
+ *
+ * @description
  * Creates a token when a user logs in also stores the bc_customer_id in the payload
  * which can be used for later request to the Mesh.
  * @param {number} entityId - Bc User Id returned from logging in


### PR DESCRIPTION
Provide services for the following operations commonly used in the mesh:

- Get the customer impersonation token, from the cache if possible
- Generate a JWT for a logged in customer, and extract their customer id from such a JWT

I have also:
- deprecated existing methods for these operations
- used the token service for automatically injecting the customer impersonation token in the graphql client
- modified two resolvers to use the new services as examples