### PR TITLE
MI-121: Updates the "generateMeshToken" function to return a "custome…

### DIFF
--- a/packages/modules/bigcommerce/release-notes.md
+++ b/packages/modules/bigcommerce/release-notes.md
@@ -1,5 +1,19 @@
 # BigCommerce GraphQl Module Release Notes
 
+## bigcommerce-graphql-module-1.0.8
+
+#### Changes:
+
+- Updates the "generateMeshToken" function to return a "customer_id" property instead of "bc_customer_id".
+Updates the "getBcCustomerIdFromMeshToken" function to look for a "customer_id" property instead of "bc_customer_id".
+This is due to the Auth Module generating a JWT containing a "customer_id" property
+but the BigCommerce Module decodes the JWT and looks for a "bc_customer_id" property.
+
+#### Tickets
+
+- MI-121: Auth module authentication issue
+  - https://aligent.atlassian.net/browse/MI-121
+
 ## bigcommerce-graphql-module-1.0.6
 
 #### Changes:

--- a/packages/modules/bigcommerce/src/types/index.ts
+++ b/packages/modules/bigcommerce/src/types/index.ts
@@ -181,7 +181,7 @@ export interface DecodedCustomerImpersonationToken {
 }
 
 export interface MeshToken {
-    bc_customer_id: number;
+    customer_id: number;
     iat: number;
     exp: number;
 }

--- a/packages/modules/bigcommerce/src/utils/tokens.ts
+++ b/packages/modules/bigcommerce/src/utils/tokens.ts
@@ -24,7 +24,7 @@ export const getDecodedCustomerImpersonationToken = (
 };
 
 /**
- * Attempts to extract "bc_customer_id" for the mesh token or throws an error
+ * Attempts to extract "customer_id" for the mesh token or throws an error
  * @param meshToken
  */
 export const getBcCustomerIdFromMeshToken = (meshToken: string): number => {
@@ -32,7 +32,7 @@ export const getBcCustomerIdFromMeshToken = (meshToken: string): number => {
         if (meshToken?.toLowerCase().startsWith('bearer')) {
             const splitMeshToken = meshToken.split(' ')[1];
             const decodedMeshToken = verify(splitMeshToken, JWT_PRIVATE_KEY) as MeshToken;
-            return decodedMeshToken.bc_customer_id;
+            return decodedMeshToken.customer_id;
         } else {
             throw new Error(`Need to send Bearer token`);
         }
@@ -48,13 +48,13 @@ export const getBcCustomerIdFromMeshToken = (meshToken: string): number => {
 };
 
 /**
- * Creates a token when a user logs in also stores the bc_customer_id in the payload
+ * Creates a token when a user logs in also stores the customer_id in the payload
  * which can be used for later request to the Mesh.
  * @param {number} entityId - Bc User Id returned from logging in
  */
 export const generateMeshToken = (entityId: number): string => {
     const payload = {
-        bc_customer_id: entityId,
+        customer_id: entityId,
         exp: getUnixTimeStampInSecondsForMidnightTonight(),
     };
 


### PR DESCRIPTION
The Auth module had been updated to generate an auth JWT containing a generic "customer_id" property rather than one named "bc_customer_id". This had an undesired affect when the Auth module was used in the BigCommerce module because the function that decodes the auth JWT looks for a "bc_customer_id" property which no longer existed. The BigCommerce module is being updated to also have a generic naming convention so the "bc_customer_id" property is now named "customer_id".