### PR TITLE
MI-168: Use more specific type than autogenerated NormalPage in getTransformedPageData parameters

### DIFF
--- a/packages/modules/bigcommerce/src/factories/__tests__/__data__/normal-page-data.ts
+++ b/packages/modules/bigcommerce/src/factories/__tests__/__data__/normal-page-data.ts
@@ -1,5 +1,3 @@
-import { CmsPage } from '@aligent/bigcommerce-resolvers';
-
 export const bcHomePageContent = {
     id: 'Tm9ybWFsUGFnZToxNw==',
     path: '/home/',
@@ -59,7 +57,7 @@ export const bcHomePageContentWithImages = {
     __typename: 'NormalPage',
 };
 
-export const transformedHomePageContent: CmsPage = {
+export const transformedHomePageContent = {
     __typename: 'CmsPage',
     url_key: 'home',
     content: '<p>This is the test homepage</p>',
@@ -72,7 +70,7 @@ export const transformedHomePageContent: CmsPage = {
     redirect_code: 0,
 };
 
-export const transformedHomePageContentWithImages: CmsPage = {
+export const transformedHomePageContentWithImages = {
     url_key: 'chamal-image-test',
     content:
         '<p><img class="__mce_add_custom__" title="half-banner-2.jpg" src="https://cdn11.bigcommerce.com/s-xxxxxx/product_images/uploaded_images/half-banner-2.jpg" alt="half-banner-2.jpg" width="900" height="376" /></p>',

--- a/packages/modules/bigcommerce/src/factories/__tests__/__data__/normal-page-data.ts
+++ b/packages/modules/bigcommerce/src/factories/__tests__/__data__/normal-page-data.ts
@@ -1,7 +1,6 @@
-import { NormalPage } from '@aligent/bigcommerce-operations';
 import { CmsPage } from '@aligent/bigcommerce-resolvers';
 
-export const bcHomePageContent: NormalPage = {
+export const bcHomePageContent = {
     id: 'Tm9ybWFsUGFnZToxNw==',
     path: '/home/',
     htmlBody: '<p>This is the test homepage</p>',
@@ -34,7 +33,7 @@ export const bcHomePageContent: NormalPage = {
     __typename: 'NormalPage',
 };
 
-export const bcHomePageContentWithImages: NormalPage = {
+export const bcHomePageContentWithImages = {
     id: 'Tm9ybWFsUGFnZToyMw==',
     path: '/chamal-image-test/',
     htmlBody:

--- a/packages/modules/bigcommerce/src/factories/get-transformed-page-data.ts
+++ b/packages/modules/bigcommerce/src/factories/get-transformed-page-data.ts
@@ -1,9 +1,16 @@
-import { NormalPage, RawHtmlPage } from '@aligent/bigcommerce-operations';
+import { SeoDetailsFragment } from '@aligent/bigcommerce-operations';
 import { CmsPage } from '@aligent/bigcommerce-resolvers';
 
 const CND_MASK = /%%GLOBAL_CdnStorePath%%/g;
 
-export const getTransformedPageData = (data: NormalPage | RawHtmlPage, cdnUrl: string): CmsPage => {
+type PageData = {
+    path: string;
+    htmlBody: string;
+    name: string;
+    seo: SeoDetailsFragment;
+};
+
+export const getTransformedPageData = (data: PageData, cdnUrl: string): CmsPage => {
     const { path, htmlBody, name, seo } = data;
     return {
         url_key: path.replace(/\//g, ''),


### PR DESCRIPTION
This is a compile-time-only fix. Using the full `NormalPage` type risks breaking the build process if BigCommerce updates the graphql schema for that entity, even though the data we actually request and require has not changed shape.

This change narrows the expected type to what the getTransformedPageData function actually uses. It also removes the type declarations on test data in `normal-page-data.ts` as they aren't required. It's better to let Typescript infer whether the test data matches that required by the function being tested.