### PR TITLE
SL-443 update for when CMS page was set to hide in BC admin

### DIFF
--- a/packages/modules/bigcommerce/src/apis/graphql/route.ts
+++ b/packages/modules/bigcommerce/src/apis/graphql/route.ts
@@ -16,7 +16,9 @@ import { getRouteQuery } from './requests';
 export const getRoute = async (
     variables: SiteRouteArgs & { includeTax?: boolean },
     customerImpersonationToken: string
-): Promise<Blog | BlogPost | Brand | Category | ContactPage | NormalPage | Product | RawHtmlPage> => {
+): Promise<
+    Blog | BlogPost | Brand | Category | ContactPage | NormalPage | Product | RawHtmlPage
+> => {
     const headers = {
         Authorization: `Bearer ${customerImpersonationToken}`,
     };

--- a/packages/modules/bigcommerce/src/apis/graphql/route.ts
+++ b/packages/modules/bigcommerce/src/apis/graphql/route.ts
@@ -6,6 +6,7 @@ import {
     ContactPage,
     NormalPage,
     Product,
+    RawHtmlPage,
     SiteRouteArgs,
 } from '@aligent/bigcommerce-operations';
 import { logAndThrowError } from '@aligent/utils';
@@ -15,7 +16,7 @@ import { getRouteQuery } from './requests';
 export const getRoute = async (
     variables: SiteRouteArgs & { includeTax?: boolean },
     customerImpersonationToken: string
-): Promise<Blog | BlogPost | Brand | Category | ContactPage | NormalPage | Product> => {
+): Promise<Blog | BlogPost | Brand | Category | ContactPage | NormalPage | Product | RawHtmlPage> => {
     const headers = {
         Authorization: `Bearer ${customerImpersonationToken}`,
     };

--- a/packages/modules/bigcommerce/src/factories/__tests__/__data__/normal-page-data.ts
+++ b/packages/modules/bigcommerce/src/factories/__tests__/__data__/normal-page-data.ts
@@ -22,7 +22,7 @@ export const bcHomePageContent = {
     entityId: 17,
     parentEntityId: null,
     name: 'Big Commerce Homepage',
-    isVisibleInNavigation: false,
+    isVisibleInNavigation: true,
     seo: {
         pageTitle: '',
         metaDescription: '',

--- a/packages/modules/bigcommerce/src/factories/get-transformed-page-data.ts
+++ b/packages/modules/bigcommerce/src/factories/get-transformed-page-data.ts
@@ -8,10 +8,19 @@ type PageData = {
     htmlBody: string;
     name: string;
     seo: SeoDetailsFragment;
+    isVisibleInNavigation: boolean;
 };
 
 export const getTransformedPageData = (data: PageData, cdnUrl: string): CmsPage => {
     const { path, htmlBody, name, seo } = data;
+
+    if (data.isVisibleInNavigation === false) {
+        return {
+            redirect_code: 0,
+            __typename: 'CmsPage',
+        };
+    }
+
     return {
         url_key: path.replace(/\//g, ''),
         content: htmlBody.replace(CND_MASK, cdnUrl),

--- a/packages/modules/bigcommerce/src/resolvers/queries/route.ts
+++ b/packages/modules/bigcommerce/src/resolvers/queries/route.ts
@@ -22,7 +22,7 @@ import { getBundleItemProducts } from '../../apis/graphql/bundle-item-products';
 import { retrieveCustomerImpersonationTokenFromCache } from '../../apis/rest';
 
 interface TransformedRouteData {
-    data: Blog | BlogPost | Brand | Category | ContactPage | NormalPage | Product;
+    data: Blog | BlogPost | Brand | Category | ContactPage | NormalPage | Product | RawHtmlPage;
     storeConfig: StoreConfig & Settings;
     customerImpersonationToken: string;
     taxSettings?: TaxDisplaySettings | null;
@@ -65,6 +65,7 @@ const getTransformedRouteData = async ({
 
     if (__typename === 'NormalPage' || __typename === 'RawHtmlPage') {
         const cdnUrl = storeConfig.url.cdnUrl;
+
         return {
             ...getTransformedPageData(data as NormalPage | RawHtmlPage, cdnUrl),
             type: 'CMS_PAGE',


### PR DESCRIPTION
**Description of the proposed changes**
CMS page data from BC is being returned regardless of the "Visible" setting in BC Admin.

The fix here is to check the "isVisibleInNavigation" property on the data returned has been added.

**Screenshots (if applicable)**
![image-20250130-055605](https://github.com/user-attachments/assets/7c39451d-8dd8-48b1-9039-fa94c52cff41)

Notes to reviewers
There is a resolver for cms-pages.ts, this is just calling the route Resolver so the change is just being made in the route resolver.

SL-443: Code Review

