### PR TITLE
chore: change order of CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,6 @@
-# DevOps team owns the .github folder
-.github/ @aligent/devops
-bitbucket-pipelines.yml @aligent/devops
-
 # Microservice team own everything else
 * @aligent/microservices
 
+# DevOps team owns the .github folder
+.github/ @aligent/devops
+bitbucket-pipelines.yml @aligent/devops


### PR DESCRIPTION
**Description of the proposed changes**

Codeowners works from top to bottom. Anything listed after will take priority over previous items. Due to this the microservices team was taking priority for the `.github` and `bitbucket-pipelines.yml` files. This fixes it so DevOps correctly owns the files.

Notes to reviewers

🛈 When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback
