### PR TITLE
Updated wishlists function to work with updated BC types

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,5 +82,6 @@
     "reflect-metadata": "^0.1.13",
     "tslib": "^2.3.0",
     "uuid": "^9.0.0"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/packages/modules/bigcommerce/src/factories/helpers/transform-wishlists.ts
+++ b/packages/modules/bigcommerce/src/factories/helpers/transform-wishlists.ts
@@ -43,8 +43,9 @@ export const getTransformedWishListItems = (
     if (!wishListItems.edges) return [];
     return wishListItems.edges
         .map((wishlistItem) => {
-            if (!wishlistItem || !wishlistItem.node) return null;
+            if (!wishlistItem || !wishlistItem.node || !wishlistItem.node.product) return null;
             const { entityId, variantEntityId: wishlistItemVariantId } = wishlistItem.node;
+
             const transformedProduct = getTransformedProductData(
                 wishlistItem.node.product,
                 undefined,


### PR DESCRIPTION
**Description of the proposed changes**
Build process was erroring with BC wishlists Type error: 

packages/modules/bigcommerce/src/factories/helpers/transform-wishlists.ts:49:17 - error TS2345: Argument of type 'Maybe<Product> | undefined' is not assignable to parameter of type 'Product'.

packages/modules/bigcommerce/src/factories/helpers/transform-wishlists.ts:60:30 - error TS18049: 'wishlistItem.node.product' is possibly 'null' or 'undefined'.

Notes to reviewers
