### PR TITLE
AKD-392: fix lodash version

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "uuid": "^9.0.0"
   },
   "resolutions": {
-    "form-data": "4.0.4"
+    "form-data": "4.0.4",
+    "lodash": "^4.18.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8540,12 +8540,7 @@ lodash.throttle@^4.1.1:
   resolved "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz"
   integrity sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==
 
-lodash@^4.17.20, lodash@^4.17.21, lodash@~4.17.0:
-  version "4.17.21"
-  resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz"
-  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
-
-lodash@^4.18.1:
+lodash@^4.17.20, lodash@^4.17.21, lodash@^4.18.1, lodash@~4.17.0:
   version "4.18.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.18.1.tgz#ff2b66c1f6326d59513de2407bf881439812771c"
   integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==


### PR DESCRIPTION
**Description of the proposed changes**
- resolve lodash to a safe version 4.18.1: `@graphql-codegen/plugin-helpers` requires `lodash ~4.17.0`, e.g: 
```
"@graphql-codegen/plugin-helpers@^5.0.0", "@graphql-codegen/plugin-helpers@^5.0.1":
  version "5.0.1"
  resolved "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-5.0.1.tgz"
  integrity sha512-6L5sb9D8wptZhnhLLBcheSPU7Tg//DGWgc5tQBWX46KYTOTQHGqDpv50FxAJJOyFVJrveN9otWk9UT9/yfY4ww==
  dependencies:
    "@graphql-tools/utils" "^10.0.0"
    change-case-all "1.0.15"
    common-tags "1.8.2"
    import-from "4.0.0"
    lodash "~4.17.0"
    tslib "~2.5.0"
```
Since lodash 4.18 is backward compatible, I believe this change is fine.

**Screenshots (if applicable)**

**Other solutions considered (if any)**

**Notes to PR author**

⚠️ Please make sure the changes adhere to the guidelines mentioned [here](https://github.com/aligent/code-of-conduct/blob/main/CONTRIBUTING.md)

Notes to reviewers

🛈 When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback
