### PR TITLE
AKD-339: align BC wishlist fixtures with updated schema

### DIFF
--- a/packages/modules/bigcommerce/src/factories/helpers/__tests__/__data__/transform-customer-wishlist-data.ts
+++ b/packages/modules/bigcommerce/src/factories/helpers/__tests__/__data__/transform-customer-wishlist-data.ts
@@ -371,6 +371,12 @@ export const bcWishListItems: WishlistItemConnection = {
                             startCursor: undefined,
                         },
                     },
+                    locales: {
+                        pageInfo: {
+                            hasNextPage: false,
+                            hasPreviousPage: false,
+                        },
+                    },
                     brand: {
                         entityId: 111,
                         id: 'well',

--- a/packages/modules/bigcommerce/src/factories/helpers/__tests__/__data__/transform-customer-wishlist-data.ts
+++ b/packages/modules/bigcommerce/src/factories/helpers/__tests__/__data__/transform-customer-wishlist-data.ts
@@ -392,6 +392,12 @@ export const bcWishListItems: WishlistItemConnection = {
                                 hasPreviousPage: false,
                             },
                         },
+                        locales: {
+                            pageInfo: {
+                                hasNextPage: false,
+                                hasPreviousPage: false,
+                            },
+                        },
                         searchKeywords: [],
                         seo: {
                             metaDescription: '',
@@ -470,6 +476,14 @@ export const bcWishListItems: WishlistItemConnection = {
                                             endCursor: 'YXJyYXljb25uZWN0aW9uOjE=',
                                         },
                                     },
+                                    locales: {
+                                        pageInfo: {
+                                            hasNextPage: false,
+                                            hasPreviousPage: false,
+                                            startCursor: 'YXJyYXljb25uZWN0aW9uOjA=',
+                                            endCursor: 'YXJyYXljb25uZWN0aW9uOjE=',
+                                        },
+                                    },
                                     id: 'Q2F0ZWdvcnk6MjM=',
                                     entityId: 23,
                                     name: 'Shop All',
@@ -532,6 +546,14 @@ export const bcWishListItems: WishlistItemConnection = {
                                             endCursor: 'YXJyYXljb25uZWN0aW9uOjE=',
                                         },
                                     },
+                                    locales: {
+                                        pageInfo: {
+                                            hasNextPage: false,
+                                            hasPreviousPage: false,
+                                            startCursor: 'YXJyYXljb25uZWN0aW9uOjA=',
+                                            endCursor: 'YXJyYXljb25uZWN0aW9uOjE=',
+                                        },
+                                    },
                                     id: 'Q2F0ZWdvcnk6NTg=',
                                     entityId: 58,
                                     name: 'Women',
@@ -587,6 +609,14 @@ export const bcWishListItems: WishlistItemConnection = {
                                         },
                                     },
                                     shopByPriceRanges: {
+                                        pageInfo: {
+                                            hasNextPage: false,
+                                            hasPreviousPage: false,
+                                            startCursor: 'YXJyYXljb25uZWN0aW9uOjA=',
+                                            endCursor: 'YXJyYXljb25uZWN0aW9uOjE=',
+                                        },
+                                    },
+                                    locales: {
                                         pageInfo: {
                                             hasNextPage: false,
                                             hasPreviousPage: false,
@@ -657,6 +687,14 @@ export const bcWishListItems: WishlistItemConnection = {
                                         },
                                     },
                                     shopByPriceRanges: {
+                                        pageInfo: {
+                                            hasNextPage: false,
+                                            hasPreviousPage: false,
+                                            startCursor: 'YXJyYXljb25uZWN0aW9uOjA=',
+                                            endCursor: 'YXJyYXljb25uZWN0aW9uOjE=',
+                                        },
+                                    },
+                                    locales: {
                                         pageInfo: {
                                             hasNextPage: false,
                                             hasPreviousPage: false,
@@ -811,6 +849,7 @@ export const bcWishListItems: WishlistItemConnection = {
                     inventory: {
                         isInStock: true,
                         hasVariantInventory: true,
+                        isStockTracked: true,
                     },
                     metafields: {
                         edges: [],


### PR DESCRIPTION
## What

Adds the newly-required `locales` field (and `isStockTracked`) to the BigCommerce wishlist test fixtures so they type-check against the current BC schema.

## Why

The `Build all packages` job was failing on `main`-based builds (surfaced via #100, AKD-339 version bump) with `tsc` errors in `transform-customer-wishlist-data.ts`. Not reproducible locally because `@aligent/bigcommerce-operations` types are generated at build time from the **live** BigCommerce GraphQL API (`BC_GRAPHQL_API`), which only CI can reach.

BigCommerce added these non-nullable fields to the schema:

| Type | New required field |
|------|--------------------|
| `Product` | `locales` |
| `Brand` | `locales` |
| `Category` | `locales` |
| `ProductInventory` | `isStockTracked` |

The fixture is annotated directly (`: WishlistConnection`) rather than `as`-cast, so it must satisfy the full base types. (`tsc` reports nested mismatches first, so `Product.locales` only surfaced after the nested `Brand`/`Category` ones were fixed — hence two commits.) Other fixtures use `as` casts and were unaffected.

## Changes

- `locales` connection added to the wishlist `product`, its `brand`, and all 4 `Category` nodes (6 total), matching each parent's existing `pageInfo` style.
- `isStockTracked: true` added to the one `inventory` block.

No transform reads `locales` or `isStockTracked` (grep-confirmed), so no expected-output/assertion changes — purely type alignment.

## Testing

- `nx test bigcommerce-graphql-module`: 184 passed
- `nx lint bigcommerce-graphql-module`: clean
- **CI green** — `Build (bigcommerce-mesh)` + `Build (orocommerce-mesh)` now pass, confirming the fixtures type-check against the live schema. This also validates the `locales` shape (`{ pageInfo: {...} }`, no `edges`) inferred from sibling connections.
